### PR TITLE
Improve log summary code

### DIFF
--- a/ConfigParser.py
+++ b/ConfigParser.py
@@ -90,7 +90,6 @@ class Config:
     # XXX is it ever permissible to have a domain with an acceptable-mx 
     # that does not point to a TLS security policy?  If not, check/warn/fail
     # here
-    print self.tls_policies
 
   def get_address_domains(self, mx_hostname):
     labels = mx_hostname.split(".")

--- a/MTAConfigGenerator.py
+++ b/MTAConfigGenerator.py
@@ -132,11 +132,11 @@ class PostfixConfigGenerator(MTAConfigGenerator):
       entry = address_domain + " encrypt"
       if "min-tls-version" in mx_policy:
         if mx_policy["min-tls-version"].lower() == "tlsv1":
-          entry += " protocols=!SSLv2,!SSLv3"
+          entry += " protocols=!SSLv2:!SSLv3"
         elif mx_policy["min-tls-version"].lower() == "tlsv1.1":
-          entry += " protocols=!SSLv2,!SSLv3,!TLSv1"
+          entry += " protocols=!SSLv2:!SSLv3:!TLSv1"
         elif mx_policy["min-tls-version"].lower() == "tlsv1.2":
-          entry += " protocols=!SSLv2,!SSLv3,!TLSv1,!TLSv1.1"
+          entry += " protocols=!SSLv2:!SSLv3:!TLSv1:!TLSv1.1"
         else:
           print mx_policy["min-tls-version"]
       self.policy_lines.append(entry)


### PR DESCRIPTION
The log summary function now looks specifically for deferred lines, which are more indicative of problems with remote mailserver configs. It also has a 'cron mode' that produces no output if everything is fine. Currently cron mode doesn't do anything with trusted/untrusted log lines, because we don't yet have any hosts configured for cert verification.

Future work: Add more useful detail to the error output, notify any endpoints specified in the starttls config.

cc @pde for code review.